### PR TITLE
feat: add intelligent design type detection for multi-page designs

### DIFF
--- a/client.html
+++ b/client.html
@@ -498,7 +498,7 @@
                     <textarea 
                         id="prompt" 
                         name="prompt" 
-                        placeholder="Describe your design idea... (e.g., 'Create a modern business card for a tech startup' or 'Design an Instagram post about sustainable living')"
+                        placeholder="Describe your design idea... For multi-page designs, try: 'Create a 5-slide presentation about...' or 'Design a business proposal for...'"
                         required
                     ></textarea>
                 </div>
@@ -795,14 +795,18 @@
 
         // Enhanced placeholder suggestions
         const designExamples = [
-            "Create a modern business card for a tech startup",
-            "Design an Instagram post about sustainable living",
-            "Make a presentation slide about AI innovation",
-            "Create a logo for a coffee shop called 'Bean There'",
+            "Create a 5-slide presentation about AI innovation",
+            "Design a business proposal for a new startup",
+            "Make a multi-page document about sustainable living",
+            "Create a presentation deck for quarterly results",
+            "Design an Instagram post about coffee culture",
+            "Make a report on market analysis with multiple pages",
+            "Create a business card for a tech consultant",
             "Design a flyer for a yoga studio grand opening",
-            "Make a social media post for a book launch",
+            "Make a logo for a coffee shop called 'Bean There'",
             "Create a poster for a music festival",
-            "Design a LinkedIn banner for a marketing consultant"
+            "Design a slideshow about company culture",
+            "Make a document guide for remote work best practices"
         ];
 
         // Dynamic placeholder rotation


### PR DESCRIPTION
- Parse prompts to detect design types (presentation, document, proposal, report)
- Automatically set design_type parameter for Canva MCP generate-design tool
- Multi-page types: presentation, document, proposal, report
- Single-page types: instagram_post, flyer, poster, business_card, logo, etc.
- Enhanced UI placeholders to suggest multi-page design prompts
- Improved prompt parsing to clean up queries after type detection